### PR TITLE
Added GitHub Actions to automate packaging

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+; Top-most http://editorconfig.org/ file
+root = true
+charset = utf-8
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -5,6 +5,7 @@ env:
     FREETYPE_VERSION: VER-2-13-0 # Make sure this matches the version mentioned in the description in the .nuspec file.
 
 on:
+    pull_request:
     workflow_call:
     workflow_dispatch:
 

--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -1,0 +1,138 @@
+name: Build native dependencies (FreeType)
+
+# Change target FreeType version based on https://github.com/freetype/freetype/tags.
+env:
+    FREETYPE_VERSION: VER-2-13-0 # Make sure this matches the version mentioned in the description in the .nuspec file.
+
+on:
+    workflow_call:
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    windows:
+        name: Windows (x86 + x64)
+        runs-on: ubuntu-22.04
+        steps:
+            - name: Clone repository
+              uses: actions/checkout@v3
+
+            - name: Setup Dependencies
+              run: |
+                mkdir -p artifacts/x86
+                mkdir artifacts/x64
+                sudo apt-get install mingw-w64
+
+            - name: Compile natives
+              run: |
+                curl -s -L -O https://github.com/freetype/freetype/archive/refs/tags/${FREETYPE_VERSION}.zip
+                unzip ${FREETYPE_VERSION}.zip
+                mkdir freetype-${FREETYPE_VERSION}/build
+                cd freetype-${FREETYPE_VERSION}
+                patch -p0 < ../win64.patch
+                cd build
+                cmake .. -DCMAKE_TOOLCHAIN_FILE=../../mingw-x86.cmake -DBUILD_SHARED_LIBS=true -DCMAKE_BUILD_TYPE=Release -DFT_DISABLE_ZLIB=TRUE -DFT_DISABLE_BZIP2=TRUE -DFT_DISABLE_PNG=TRUE -DFT_DISABLE_HARFBUZZ=TRUE -DFT_DISABLE_BROTLI=TRUE -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc"
+                cmake --build .
+                cp libfreetype.dll ../../artifacts/x86/freetype6.dll
+                rm -rf *
+                cmake .. -DCMAKE_TOOLCHAIN_FILE=../../mingw-x64.cmake -DBUILD_SHARED_LIBS=true -DCMAKE_BUILD_TYPE=Release -DFT_DISABLE_ZLIB=TRUE -DFT_DISABLE_BZIP2=TRUE -DFT_DISABLE_PNG=TRUE -DFT_DISABLE_HARFBUZZ=TRUE -DFT_DISABLE_BROTLI=TRUE
+                cmake --build .
+                cp libfreetype.dll ../../artifacts/x64/freetype6.dll
+
+            - name: Upload Artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                name: Natives-Windows
+                path: ./artifacts
+
+    macos:
+        name: macOS (x64 + arm64)
+        runs-on: macos-11
+        steps:
+            - name: Setup Dependencies
+              run: |
+                mkdir -p artifacts/x86_64
+                mkdir artifacts/arm64
+
+            - name: Compile natives
+              run: |
+                curl -s -L -O https://github.com/freetype/freetype/archive/refs/tags/${FREETYPE_VERSION}.zip
+                unzip ${FREETYPE_VERSION}.zip
+                cd freetype-${FREETYPE_VERSION}
+                cmake -B build -DBUILD_SHARED_LIBS=true -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 -DFT_DISABLE_ZLIB=TRUE -DFT_DISABLE_BZIP2=TRUE -DFT_DISABLE_PNG=TRUE -DFT_DISABLE_HARFBUZZ=TRUE -DFT_DISABLE_BROTLI=TRUE
+                cmake --build build
+                lipo -thin x86_64 build/libfreetype.6.dylib -output ../artifacts/x86_64/freetype6.dylib
+                lipo -thin arm64 build/libfreetype.6.dylib -output ../artifacts/arm64/freetype6.dylib
+
+            - name: Upload Artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                name: Natives-MacOS
+                path: ./artifacts
+
+    # Note: Running inside a CentOS container because we want to compile using a version of glibc
+    # that is as old as reasonably possible to ensure backwards compatibility of the compiled binaries.
+    linux-x64:
+        name: Linux (x64)
+        runs-on: ubuntu-22.04
+        container: centos:centos7
+        steps:
+            - name: Setup Dependencies
+              run: |
+                mkdir -p artifacts/x64
+                yum -y install https://repo.ius.io/ius-release-el7.rpm centos-release-scl
+                yum -y install devtoolset-8 cmake3
+
+            - name: Compile natives
+              run: |
+                curl -s -L -O https://github.com/freetype/freetype/archive/refs/tags/${FREETYPE_VERSION}.zip
+                unzip ${FREETYPE_VERSION}.zip
+                mkdir freetype-${FREETYPE_VERSION}/build
+                cd freetype-${FREETYPE_VERSION}/build
+                cmake3 .. -DBUILD_SHARED_LIBS=true -DCMAKE_BUILD_TYPE=Release -DFT_DISABLE_ZLIB=TRUE -DFT_DISABLE_BZIP2=TRUE -DFT_DISABLE_PNG=TRUE -DFT_DISABLE_HARFBUZZ=TRUE -DFT_DISABLE_BROTLI=TRUE
+                cmake3 --build .
+                cp libfreetype.so ../../artifacts/x64/freetype6.so
+
+            - name: Upload Artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                name: Natives-Linux(x64)
+                path: ./artifacts
+
+    # Note: Using the run-on-arch action is *very* slow, but is the only way to simulate arm64 architecture.
+    linux-arm64:
+        name: Linux (arm64)
+        runs-on: ubuntu-22.04
+        steps:
+            - name: Setup dependencies and compile natives
+              uses: uraimo/run-on-arch-action@v2
+              with:
+                arch: aarch64
+                distro: ubuntu22.04
+                shell: /bin/sh
+                githubToken: ${{ github.token }}
+                setup: |
+                  mkdir -p "${PWD}/artifacts/arm64"
+                dockerRunArgs: |
+                  --volume "${PWD}/artifacts:/artifacts"
+                env: |
+                  FREETYPE_VERSION: ${{ env.FREETYPE_VERSION }}
+                install: |
+                  apt-get update -q -y
+                  apt-get install -y build-essential curl cmake unzip
+                run: |
+                  curl -s -L -O https://github.com/freetype/freetype/archive/refs/tags/${FREETYPE_VERSION}.zip
+                  unzip ${FREETYPE_VERSION}.zip
+                  mkdir freetype-${FREETYPE_VERSION}/build
+                  cd freetype-${FREETYPE_VERSION}/build
+                  cmake .. -DBUILD_SHARED_LIBS=true -DCMAKE_BUILD_TYPE=Release -DFT_DISABLE_ZLIB=TRUE -DFT_DISABLE_BZIP2=TRUE -DFT_DISABLE_PNG=TRUE -DFT_DISABLE_HARFBUZZ=TRUE -DFT_DISABLE_BROTLI=TRUE
+                  cmake --build .
+                  cp libfreetype.so /artifacts/arm64/freetype6.so
+
+            - name: Upload Artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                name: Natives-Linux(arm64)
+                path: ./artifacts

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -1,0 +1,94 @@
+name: Package NuGet
+
+on:
+    push:
+        tags:
+            - '*'
+    workflow_dispatch:
+        inputs:
+            nugetPackageVersion:
+                description: "NuGet package version"
+                required: true
+            shouldCreateTag:
+                description: "Create a git tag + Release?"
+                required: true
+                type: boolean
+                default: true
+
+permissions:
+    contents: write # "write" needed for the "Tag a release" step.
+
+jobs:
+    compile-natives:
+        name: Build native dependencies
+        uses: ./.github/workflows/build-natives.yml
+
+    package-nuget:
+        name: Package NuGet
+        runs-on: ubuntu-22.04
+        needs: [compile-natives]
+        steps:
+            - name: Clone repository
+              uses: actions/checkout@v3
+
+            - name: Prepare environment variables
+              run: |
+                if [ "${{ github.event_name }}" = "push" ]; then
+                    echo "PACKAGE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+                    echo "SHOULD_TAG_RELEASE=true" >> $GITHUB_ENV
+                else
+                    echo "PACKAGE_VERSION=${{ github.event.inputs.nugetPackageVersion }}" >> $GITHUB_ENV
+                    echo "SHOULD_TAG_RELEASE=${{ github.event.inputs.shouldCreateTag }}" >> $GITHUB_ENV
+                fi
+
+            - name: Download artifacts - native - Windows
+              uses: actions/download-artifact@v3
+              with:
+                name: Natives-Windows
+                path: ./native/win
+
+            - name: Download artifacts - native - MacOS
+              uses: actions/download-artifact@v3
+              with:
+                name: Natives-MacOS
+                path: ./native/osx
+
+            - name: Download artifacts - native - Linux (x64)
+              uses: actions/download-artifact@v3
+              with:
+                name: Natives-Linux(x64)
+                path: ./native/linux
+
+            - name: Download artifacts - native - Linux (arm64)
+              uses: actions/download-artifact@v3
+              with:
+                name: Natives-Linux(arm64)
+                path: ./native/linux
+
+            - name: Setup NuGet.exe
+              uses: NuGet/setup-nuget@v1
+
+            - name: Package NuGet
+              run: |
+                nuget pack OpenRA-FreeType6.nuspec -OutputDirectory ./nuget -version ${{ github.event.inputs.nugetPackageVersion }}
+
+            - name: Upload NuGet package to Artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                name: NuGet Package ${{ github.event.inputs.nugetPackageVersion }}
+                path: ./nuget
+
+            - name: Tag a release
+              if: ${{ env.SHOULD_TAG_RELEASE == 'true' }}
+              uses: svenstaro/upload-release-action@v2
+              with:
+                repo_token: ${{ secrets.GITHUB_TOKEN }}
+                tag: ${{ env.PACKAGE_VERSION }}
+                overwrite: true
+                file_glob: true
+                file: ./nuget/*.nupkg
+
+            - name: Publish package to NuGet
+              if: ${{ env.SHOULD_TAG_RELEASE == 'true' }}
+              run: |
+                nuget push ./nuget/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_KEY }}

--- a/OpenRA-FreeType6.nuspec
+++ b/OpenRA-FreeType6.nuspec
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>OpenRA-Freetype6</id>
+    <version>0.0.1</version> <!-- Version is set during packaging. -->
+    <authors>OpenRA</authors>
+    <owners>OpenRA</owners>
+    <projectUrl>https://github.com/OpenRA/FreeType</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>
+    This is a version of FreeType patched and packaged for OpenRA.
+    The package includes the native binaries for FreeType 2.13.0.
+    </description>
+    <!-- Copyright claim taken from their GitHub repository. -->
+    <copyright>
+    Copyright (C) 2013-2023 by David Turner, Robert Wilhelm, and Werner Lemberg
+    </copyright>
+    <license type="expression">FTL OR GPL-2.0-only</license>
+    <tags>OpenRA natives FreeType</tags>
+    <releaseNotes>
+    </releaseNotes>
+  </metadata>
+  <files>
+    <file src="OpenRA-Freetype6.targets" target="build" />
+    <file src="native/win/x86/freetype6.dll" target="native/win-x86" />
+    <file src="native/win/x64/freetype6.dll" target="native/win-x64" />
+    <file src="native/linux/x64/freetype6.so" target="native/linux-x64" />
+    <file src="native/linux/arm64/freetype6.so" target="native/linux-arm64" />
+    <file src="native/osx/x86_64/freetype6.dylib" target="native/osx-x64" />
+    <file src="native/osx/arm64/freetype6.dylib" target="native/osx-arm64" />
+  </files>
+</package>

--- a/OpenRA-FreeType6.targets
+++ b/OpenRA-FreeType6.targets
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)\..\native\win-x86\freetype6.dll" Condition="'$(TargetPlatform)' == 'win-x86'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>freetype6.dll</Link>
+      <Visible>false</Visible>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)\..\native\win-x64\freetype6.dll" Condition="'$(TargetPlatform)' == 'win-x64'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>freetype6.dll</Link>
+      <Visible>false</Visible>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)\..\native\linux-x64\freetype6.so" Condition="'$(TargetPlatform)' == 'linux-x64'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>freetype6.so</Link>
+      <Visible>false</Visible>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)\..\native\linux-arm64\freetype6.so" Condition="'$(TargetPlatform)' == 'linux-arm64'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>freetype6.so</Link>
+      <Visible>false</Visible>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)\..\native\osx-x64\freetype6.dylib" Condition="'$(TargetPlatform)' == 'osx-x64'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>freetype6.dylib</Link>
+      <Visible>false</Visible>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)\..\native\osx-arm64\freetype6.dylib" Condition="'$(TargetPlatform)' == 'osx-arm64'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>freetype6.dylib</Link>
+      <Visible>false</Visible>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/mingw-x64.cmake
+++ b/mingw-x64.cmake
@@ -1,0 +1,24 @@
+# Sample toolchain file for building for Windows from an Ubuntu Linux system.
+#
+# Typical usage:
+#    *) install cross compiler: `sudo apt-get install mingw-w64`
+#    *) cd build
+#    *) cmake -DCMAKE_TOOLCHAIN_FILE=~/mingw-w64-x86_64.cmake ..
+# This is free and unencumbered software released into the public domain.
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
+
+# cross compilers to use for C, C++ and Fortran
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_Fortran_COMPILER ${TOOLCHAIN_PREFIX}-gfortran)
+set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
+
+# target environment on the build host system
+set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+# modify default behavior of FIND_XXX() commands
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/mingw-x86.cmake
+++ b/mingw-x86.cmake
@@ -1,0 +1,24 @@
+# Sample toolchain file for building for Windows from an Ubuntu Linux system.
+#
+# Typical usage:
+#    *) install cross compiler: `sudo apt-get install mingw-w64`
+#    *) cd build
+#    *) cmake -DCMAKE_TOOLCHAIN_FILE=~/mingw-w64-x86_64.cmake ..
+# This is free and unencumbered software released into the public domain.
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(TOOLCHAIN_PREFIX i686-w64-mingw32)
+
+# cross compilers to use for C, C++ and Fortran
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_Fortran_COMPILER ${TOOLCHAIN_PREFIX}-gfortran)
+set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
+
+# target environment on the build host system
+set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+# modify default behavior of FIND_XXX() commands
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/win64.patch
+++ b/win64.patch
@@ -1,0 +1,71 @@
+diff -pNaur include/freetype/ftimage.h include/freetype/ftimage.h
+--- include/freetype/ftimage.h
++++ include/freetype/ftimage.h
+@@ -49,7 +49,11 @@ FT_BEGIN_HEADER
+    *   the context, these can represent distances in integer font units, or
+    *   16.16, or 26.6 fixed-point pixel coordinates.
+    */
+-  typedef signed long  FT_Pos;
++  #if _WIN64
++    typedef signed __int64 FT_Pos;
++  #else
++    typedef signed long FT_Pos;
++  #endif
+ 
+ 
+   /**************************************************************************
+diff -pNaur include/freetype/fttypes.h include/freetype/fttypes.h
+--- include/freetype/fttypes.h
++++ include/freetype/fttypes.h
+@@ -239,7 +239,11 @@ FT_BEGIN_HEADER
+    * @description:
+    *   A typedef for signed long.
+    */
+-  typedef signed long  FT_Long;
++  #if _WIN64
++    typedef signed __int64  FT_Long;
++  #else
++    typedef signed long FT_Long;
++  #endif
+ 
+ 
+   /**************************************************************************
+@@ -250,7 +254,11 @@ FT_BEGIN_HEADER
+    * @description:
+    *   A typedef for unsigned long.
+    */
+-  typedef unsigned long  FT_ULong;
++  #if _WIN64
++    typedef unsigned __int64  FT_ULong;
++  #else
++    typedef unsigned long FT_ULong;
++  #endif
+ 
+ 
+   /**************************************************************************
+@@ -272,7 +280,11 @@ FT_BEGIN_HEADER
+    * @description:
+    *   A signed 26.6 fixed-point type used for vectorial pixel coordinates.
+    */
+-  typedef signed long  FT_F26Dot6;
++  #if _WIN64
++    typedef signed __int64  FT_F26Dot6;
++  #else
++    typedef unsigned long FT_F26Dot6;
++  #endif
+ 
+ 
+   /**************************************************************************
+@@ -284,7 +296,11 @@ FT_BEGIN_HEADER
+    *   This type is used to store 16.16 fixed-point values, like scaling
+    *   values or matrix coefficients.
+    */
+-  typedef signed long  FT_Fixed;
++  #if _WIN64
++    typedef signed __int64  FT_Fixed;
++  #else
++    typedef unsigned long FT_Fixed;
++  #endif
+ 
+ 
+   /**************************************************************************


### PR DESCRIPTION
Same as https://github.com/OpenRA/Eluant/pull/5, https://github.com/OpenRA/OpenAL-CS/pull/4 and https://github.com/OpenRA/SDL2-CS/pull/6:

Adding 2 workflows to automate compiling of native dependencies and packaging it all into a NuGet package and publishing that.

The native binary compilation steps are taken from @pchote's https://github.com/pchote/native-dependencies

For results of a successful run see:
https://github.com/penev92/FreeType/actions/runs/4870852735
https://www.nuget.org/packages/OpenRA-Freetype6/1.0.10-a2

P.S.: I added a few improvements over the previous PRs which I plan on porting back later to the other 3 repositories.